### PR TITLE
fix(release): correct docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ tempfile = "3.1.0"
 assert_matches = "1.3.0"
 tokio = {version = "0.2.21", features = ["rt-threaded", "macros"]}
 
-[package.metadata.doc.rs]
+[package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
The table name had beens specified using "doc.rs" instead of "docs.rs".
This prevented docs.rs from picking up the "all-feature" flag.