### PR TITLE
fix(release): correct stored credentials error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
             uses: actions/checkout@v2
             with:
                 fetch-depth: 0
+                persist-credentials: false
 
           - name: Install Rust Stable
             uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The lack of "persist-credentials: false" on the Checkout step appears
to have interfered with the used of the personal access token in the
Semantic Release step which caused semantic release to error in the
git plugin. Add "persist-credentials: false" to correct this.