### PR TITLE
fix(release): update semantic-release-rust version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             uses: actions-rs/cargo@v1
             with:
                 command: install
-                args: --git https://github.com/sbosnick/semantic-release-rust --tag v1.0.0-alpha.5
+                args: --git https://github.com/kettleby/semantic-release-rust --tag v1.0.0-alpha.6
 
           - name: Stable Test
             uses: actions-rs/cargo@v1


### PR DESCRIPTION
Change the version of semantic-release-rust to v1.0.0-alpha.6 and change its GitHub location to the kettleby organization.