### PR TITLE
ci: add audit check workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Security Audit
+on:
+    schedule:
+        - cron: 0 0 1,15 * *
+    push:
+        paths:
+            - '**/Cargo.toml'
+
+jobs:
+    security_audit:
+        runs-on: ubuntu-latest
+        if: github.actor != 'sbosnick-bot'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v1
+            - name: Audit
+              uses: actions-rs/audit-check@v1
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow will run the audit-check action twice a month or when
a Cargo.toml file change. This is gated on the github actor not being
'sbosnick-bot' to avoid running this in response to the release
workflow.

Closes: #4