### PR TITLE
ci: change install of semantic-release-rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             uses: actions-rs/cargo@v1
             with:
                 command: install
-                args: --version v1.0.0-alpha.6
+                args: semantic-release-rust --version v1.0.0-alpha.6
 
           - name: Stable Test
             uses: actions-rs/cargo@v1


### PR DESCRIPTION
The previous change was failing because it left out the name of the create to install. Add the name of semantic-release-rust to the Install Semantic Release Rust step.