### PR TITLE
ci(release): fix version of semantic-release-rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             uses: actions-rs/cargo@v1
             with:
                 command: install
-                args: semantic-release-rust --version v1.0.0-alpha.6
+                args: semantic-release-rust --version 1.0.0-alpha.6
 
           - name: Stable Test
             uses: actions-rs/cargo@v1


### PR DESCRIPTION
The prior specification of the version was using a git tag instead of a semantic version.