### PR TITLE
refactor(net): remove nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ keywords = ["fd", "unix", "socket", "domain"]
 categories = ["asynchronous", "os::unix-apis"]
 
 [features]
-net-fd = ["nix", "tracing"]
+net-fd = ["tracing"]
 mio-fd = ["net-fd", "mio"]
 tokio-fd = ["mio-fd", "tokio", "socket2", "pin-project", "futures-core", "futures-util"]
 # TODO: remove this; temporary to work around rust-analyzer issue
 default = ["net-fd"]
 
 [dependencies]
-nix = {version = "0.17.0", optional = true}
 tracing = {version = "0.1.15", optional = true}
 mio = {version = "0.6.22", optional = true}
 tokio = {version = "0.2.21", optional = true, features = ["io-driver", "io-util"]}
@@ -30,6 +29,7 @@ libc = "0.2.80"
 num-traits = "0.2.14"
 
 [dev-dependencies]
+nix = "0.17.0"
 tempfile = "3.1.0"
 assert_matches = "1.3.0"
 tokio = {version = "0.2.21", features = ["rt-threaded", "macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ categories = ["asynchronous", "os::unix-apis"]
 net-fd = ["tracing"]
 mio-fd = ["net-fd", "mio"]
 tokio-fd = ["mio-fd", "tokio", "socket2", "pin-project", "futures-core", "futures-util"]
-# TODO: remove this; temporary to work around rust-analyzer issue
-default = ["net-fd"]
 
 [dependencies]
 tracing = {version = "0.1.15", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ categories = ["asynchronous", "os::unix-apis"]
 net-fd = ["nix", "tracing"]
 mio-fd = ["net-fd", "mio"]
 tokio-fd = ["mio-fd", "tokio", "socket2", "pin-project", "futures-core", "futures-util"]
+# TODO: remove this; temporary to work around rust-analyzer issue
+default = ["net-fd"]
 
 [dependencies]
 nix = {version = "0.17.0", optional = true}
@@ -24,11 +26,16 @@ pin-project = {version = "0.4.22", optional = true}
 futures-core = {version = "0.3.5", optional = true}
 futures-util = {version = "0.3.5", optional = true}
 socket2 = {version = "0.3.12", optional = true, features = ["unix"]}
+libc = "0.2.80"
+num-traits = "0.2.14"
 
 [dev-dependencies]
 tempfile = "3.1.0"
 assert_matches = "1.3.0"
 tokio = {version = "0.2.21", features = ["rt-threaded", "macros"]}
+
+[build-dependencies]
+libc = "0.2.80"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+// Copyright 2020 Steven Bosnick
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE-2.0 or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms
+
+use std::{
+    os::unix::io::RawFd,
+    mem,
+    io::Write,
+    env::var_os, path::Path, fs::File, io::BufWriter};
+
+use libc::c_uint;
+
+const MAX_FD_COUNT: usize = 10;
+
+fn main() {
+    // Safety: CMSG_SPACE is safe
+    let scm_rights_space = unsafe {libc::CMSG_SPACE((MAX_FD_COUNT * mem::size_of::<RawFd>()) as c_uint)};
+
+    let path = var_os("OUT_DIR")
+        .map(|s| Path::new(&s).join("constants.rs"))
+        .expect("Can't find OUT_DIR");
+    let mut output = File::create(path)
+        .map(BufWriter::new)
+        .expect("Can't create constants.rs file");
+
+    write!(output, "/// the result of `libc::CMSG_SPACE()` for `MAX_FD_COUNT` `RawFd`'s\n\
+                    pub const CMSG_SCM_RIGHTS_SPACE: libc::c_uint = {};\n\
+                    \n\
+                    /// the maximum number of `RawFd`'s to transfer in a single call to \n\
+                    /// `libc::sendmsg` or `libc::recvmsg`.\n\
+                    pub const MAX_FD_COUNT: usize = {};\n", scm_rights_space, MAX_FD_COUNT)
+        .expect("Can't write to constants.rs");
+}

--- a/build.rs
+++ b/build.rs
@@ -6,11 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms
 
-use std::{
-    os::unix::io::RawFd,
-    mem,
-    io::Write,
-    env::var_os, path::Path, fs::File, io::BufWriter};
+use std::{env::var_os, fs::File, io::BufWriter, io::Write, mem, os::unix::io::RawFd, path::Path};
 
 use libc::c_uint;
 
@@ -18,7 +14,8 @@ const MAX_FD_COUNT: usize = 10;
 
 fn main() {
     // Safety: CMSG_SPACE is safe
-    let scm_rights_space = unsafe {libc::CMSG_SPACE((MAX_FD_COUNT * mem::size_of::<RawFd>()) as c_uint)};
+    let scm_rights_space =
+        unsafe { libc::CMSG_SPACE((MAX_FD_COUNT * mem::size_of::<RawFd>()) as c_uint) };
 
     let path = var_os("OUT_DIR")
         .map(|s| Path::new(&s).join("constants.rs"))
@@ -27,11 +24,15 @@ fn main() {
         .map(BufWriter::new)
         .expect("Can't create constants.rs file");
 
-    write!(output, "/// the result of `libc::CMSG_SPACE()` for `MAX_FD_COUNT` `RawFd`'s\n\
-                    pub const CMSG_SCM_RIGHTS_SPACE: libc::c_uint = {};\n\
-                    \n\
-                    /// the maximum number of `RawFd`'s to transfer in a single call to \n\
-                    /// `libc::sendmsg` or `libc::recvmsg`.\n\
-                    pub const MAX_FD_COUNT: usize = {};\n", scm_rights_space, MAX_FD_COUNT)
-        .expect("Can't write to constants.rs");
+    write!(
+        output,
+        "/// the result of `libc::CMSG_SPACE()` for `MAX_FD_COUNT` `RawFd`'s\n\
+         pub const CMSG_SCM_RIGHTS_SPACE: libc::c_uint = {};\n\
+         \n\
+         /// the maximum number of `RawFd`'s to transfer in a single call to \n\
+         /// `libc::sendmsg` or `libc::recvmsg`.\n\
+         pub const MAX_FD_COUNT: usize = {};\n",
+        scm_rights_space, MAX_FD_COUNT
+    )
+    .expect("Can't write to constants.rs");
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -6,18 +6,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms
 
-use std::collections::VecDeque;
-use std::fmt;
-use std::iter;
-use std::io::{self, prelude::*, Error, ErrorKind, IoSlice, IoSliceMut};
-use std::mem::{self, size_of};
-use std::net::Shutdown;
-use std::ops::Neg;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::net::{SocketAddr, UnixListener as StdUnixListner, UnixStream as StdUnixStream};
-use std::path::Path;
-use std::ptr;
-use std::slice;
+use std::{
+    collections::VecDeque,
+    fmt,
+    iter,
+    io::{self, prelude::*, Error, ErrorKind, IoSlice, IoSliceMut},
+    mem,
+    net::Shutdown,
+    ops::Neg,
+    os::unix::{
+        io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
+        net::{SocketAddr, UnixListener as StdUnixListner, UnixStream as StdUnixStream},
+    },
+    path::Path,
+    ptr,
+    slice,
+};
 
 // needed until the MSRV is 1.43 when the associated constant becomes available
 use std::isize;
@@ -447,8 +451,8 @@ impl Read for UnixStream {
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        assert_eq!(size_of::<IoSliceMut>(), size_of::<IoVec<&mut [u8]>>());
-        assert!((isize::MAX as usize) / size_of::<IoVec<&mut [u8]>>() >= bufs.len());
+        assert_eq!(mem::size_of::<IoSliceMut>(), mem::size_of::<IoVec<&mut [u8]>>());
+        assert!((isize::MAX as usize) / mem::size_of::<IoVec<&mut [u8]>>() >= bufs.len());
 
         let bufs_ptr = bufs.as_mut_ptr();
         let vecs_ptr = bufs_ptr as *mut IoVec<&mut [u8]>;

--- a/src/net.rs
+++ b/src/net.rs
@@ -9,9 +9,8 @@
 use std::{
     collections::VecDeque,
     fmt,
-    iter,
     io::{self, prelude::*, Error, ErrorKind, IoSlice, IoSliceMut},
-    mem,
+    iter, mem,
     net::Shutdown,
     ops::Neg,
     os::unix::{
@@ -19,8 +18,7 @@ use std::{
         net::{SocketAddr, UnixListener as StdUnixListner, UnixStream as StdUnixStream},
     },
     path::Path,
-    ptr,
-    slice,
+    ptr, slice,
 };
 
 // needed until the MSRV is 1.43 when the associated constant becomes available
@@ -317,10 +315,12 @@ impl UnixStream {
         self.inner.set_nonblocking(nonblocking)
     }
 
-    fn send_fds(&self, bufs: &[IoSlice], fds: impl Iterator<Item=RawFd>) -> io::Result<usize> {
+    fn send_fds(&self, bufs: &[IoSlice], fds: impl Iterator<Item = RawFd>) -> io::Result<usize> {
         // Safety: CMSG_SPACE() is safe
-        debug_assert_eq!(constants::CMSG_SCM_RIGHTS_SPACE, unsafe {libc::CMSG_SPACE((constants::MAX_FD_COUNT*mem::size_of::<RawFd>()) as _)});
-        assert!( Self::FD_QUEUE_SIZE <= constants::MAX_FD_COUNT );
+        debug_assert_eq!(constants::CMSG_SCM_RIGHTS_SPACE, unsafe {
+            libc::CMSG_SPACE((constants::MAX_FD_COUNT * mem::size_of::<RawFd>()) as _)
+        });
+        assert!(Self::FD_QUEUE_SIZE <= constants::MAX_FD_COUNT);
 
         // Size the buffer to be big enough to hold MAX_FD_COUNT RawFd's.
         // The assertions above ensure that this is the case. The buffer
@@ -370,7 +370,7 @@ impl UnixStream {
             }
 
             // Safety: pmhdr points within cmsg_buffer (see above).
-            (*pmhdr).cmsg_len = libc::CMSG_LEN((count*mem::size_of::<RawFd>()) as u32) as usize;
+            (*pmhdr).cmsg_len = libc::CMSG_LEN((count * mem::size_of::<RawFd>()) as u32) as usize;
             (*pmhdr).cmsg_level = libc::SOL_SOCKET;
             (*pmhdr).cmsg_type = libc::SCM_RIGHTS;
 
@@ -383,7 +383,8 @@ impl UnixStream {
             mhdr.msg_controllen = 0;
         } else {
             // Safety: CMSG_SPACE is safe
-            mhdr.msg_controllen = unsafe { libc::CMSG_SPACE((count*mem::size_of::<RawFd>()) as u32) as usize };
+            mhdr.msg_controllen =
+                unsafe { libc::CMSG_SPACE((count * mem::size_of::<RawFd>()) as u32) as usize };
         }
 
         // Safety: mhdr has been properly prepared above.
@@ -451,7 +452,10 @@ impl Read for UnixStream {
     }
 
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        assert_eq!(mem::size_of::<IoSliceMut>(), mem::size_of::<IoVec<&mut [u8]>>());
+        assert_eq!(
+            mem::size_of::<IoSliceMut>(),
+            mem::size_of::<IoVec<&mut [u8]>>()
+        );
         assert!((isize::MAX as usize) / mem::size_of::<IoVec<&mut [u8]>>() >= bufs.len());
 
         let bufs_ptr = bufs.as_mut_ptr();
@@ -850,7 +854,7 @@ mod constants {
 fn call_res<F, R>(f: F) -> Result<R, io::Error>
 where
     F: Fn() -> R,
-    R: One+Neg<Output=R>+PartialEq,
+    R: One + Neg<Output = R> + PartialEq,
 {
     let res = f();
     if res == -R::one() {

--- a/src/net.rs
+++ b/src/net.rs
@@ -383,7 +383,7 @@ fn recv_fds(
             condition = "cmsgs truncated"
         );
 
-        Err(Error::new(ErrorKind::Other, CMsgTruncatedError::new()))
+        Err(CMsgTruncatedError::new())
     } else {
         trace!(
             source = "UnixStream",
@@ -755,8 +755,8 @@ impl Iterator for Incoming<'_> {
 
 // === impl CMsgTruncatedError ===
 impl CMsgTruncatedError {
-    fn new() -> CMsgTruncatedError {
-        CMsgTruncatedError {}
+    fn new() -> Error {
+        Error::new(ErrorKind::Other, CMsgTruncatedError {})
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -22,8 +22,7 @@ use std::{
 // needed until the MSRV is 1.43 when the associated constant becomes available
 use std::usize;
 
-use iomsg::{MsgHdr, cmsg_buffer_fds_space};
-
+use iomsg::{cmsg_buffer_fds_space, MsgHdr};
 
 use tracing::{trace, warn};
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,7 +10,7 @@ use std::{
     collections::VecDeque,
     fmt,
     io::{self, prelude::*, Error, ErrorKind, IoSlice, IoSliceMut},
-    iter, mem,
+    iter,
     net::Shutdown,
     os::unix::{
         io::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
@@ -317,10 +317,10 @@ impl UnixStream {
     }
 
     fn send_fds(&self, bufs: &[IoSlice], fds: impl Iterator<Item = RawFd>) -> io::Result<usize> {
-        // Safety: CMSG_SPACE() is safe
-        debug_assert_eq!(constants::CMSG_SCM_RIGHTS_SPACE, unsafe {
-            libc::CMSG_SPACE((constants::MAX_FD_COUNT * mem::size_of::<RawFd>()) as _)
-        });
+        debug_assert_eq!(
+            constants::CMSG_SCM_RIGHTS_SPACE as usize,
+            cmsg_buffer_fds_space(constants::MAX_FD_COUNT)
+        );
         assert!(Self::FD_QUEUE_SIZE <= constants::MAX_FD_COUNT);
 
         // Size the buffer to be big enough to hold MAX_FD_COUNT RawFd's.

--- a/src/net.rs
+++ b/src/net.rs
@@ -22,7 +22,7 @@ use std::{
 // needed until the MSRV is 1.43 when the associated constant becomes available
 use std::usize;
 
-use iomsg::{cmsg_buffer_fds_space, MsgHdr, Fd};
+use iomsg::{cmsg_buffer_fds_space, Fd, MsgHdr};
 
 use tracing::{trace, warn};
 
@@ -317,7 +317,11 @@ impl UnixStream {
     }
 }
 
-fn send_fds(sockfd: RawFd, bufs: &[IoSlice], fds: impl Iterator<Item = RawFd>) -> io::Result<usize> {
+fn send_fds(
+    sockfd: RawFd,
+    bufs: &[IoSlice],
+    fds: impl Iterator<Item = RawFd>,
+) -> io::Result<usize> {
     debug_assert_eq!(
         constants::CMSG_SCM_RIGHTS_SPACE as usize,
         cmsg_buffer_fds_space(constants::MAX_FD_COUNT)
@@ -374,9 +378,9 @@ fn recv_fds(
                 return Err(PushFailureError::new());
             }
         }
-   }
+    }
 
-   if recv.was_control_truncated() {
+    if recv.was_control_truncated() {
         warn!(
             source = "UnixStream",
             event = "read",

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -19,6 +19,9 @@ use std::{
     ptr,
 };
 
+// needed until the MSRV is 1.43 when the associated constant becomes available
+use std::isize;
+
 use libc::{
     close, cmsghdr, iovec, msghdr, recvmsg, sendmsg, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN,
     CMSG_NXTHDR, CMSG_SPACE, MSG_CTRUNC, SCM_RIGHTS, SOL_SOCKET,

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -19,8 +19,8 @@ use std::{
 };
 
 use libc::{
-    cmsghdr, iovec, msghdr, recvmsg, CMSG_DATA, CMSG_FIRSTHDR, CMSG_NXTHDR, CMSG_SPACE, MSG_CTRUNC,
-    SCM_RIGHTS, SOL_SOCKET,
+    cmsghdr, iovec, msghdr, recvmsg, CMSG_DATA, CMSG_FIRSTHDR, CMSG_NXTHDR,
+    CMSG_SPACE, MSG_CTRUNC, SCM_RIGHTS, SOL_SOCKET,
 };
 use num_traits::One;
 
@@ -35,7 +35,7 @@ pub struct MsgHdr<'a, State> {
     _phantom: PhantomData<&'a ()>,
 }
 
-// The type states fro MsgHdr.
+// The type states for MsgHdr.
 #[derive(Debug, Default)]
 pub struct RecvStart {}
 

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -20,9 +20,9 @@ use std::{
 };
 
 use libc::{
-    cmsghdr, iovec, msghdr, recvmsg, sendmsg, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR,
-    CMSG_SPACE, MSG_CTRUNC, SCM_RIGHTS, SOL_SOCKET,
-close};
+    close, cmsghdr, iovec, msghdr, recvmsg, sendmsg, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN,
+    CMSG_NXTHDR, CMSG_SPACE, MSG_CTRUNC, SCM_RIGHTS, SOL_SOCKET,
+};
 use num_traits::One;
 
 #[derive(Debug)]
@@ -199,10 +199,10 @@ impl<'a> MsgHdr<'a, RecvStart> {
         // in so msg_control will still be a valid pointer for length
         // msg_controllen.
         Ok(MsgHdrRecvEnd {
-                mhdr: self.mhdr,
-                bytes_recvieved: count,
-                fds_taken: false,
-                _phantom: PhantomData,
+            mhdr: self.mhdr,
+            bytes_recvieved: count,
+            fds_taken: false,
+            _phantom: PhantomData,
         })
     }
 }
@@ -492,7 +492,7 @@ impl<'a> Drop for FdsIter<'a> {
     fn drop(&mut self) {
         for fd in self {
             drop(fd);
-       }
+        }
     }
 }
 
@@ -598,7 +598,8 @@ impl Drop for Fd {
 
 impl IntoRawFd for Fd {
     fn into_raw_fd(mut self) -> RawFd {
-        self.fd.take()
+        self.fd
+            .take()
             .expect("Attempt to take the RawFd contained in an Fd a second time")
     }
 }

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -1,0 +1,349 @@
+// Copyright 2020 Steven Bosnick
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE-2.0 or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms
+
+//! Types to provide a safe interface around libc::recvmsg and libc::sendmsg.
+
+use std::{
+    io::{IoSlice, IoSliceMut},
+    marker::PhantomData,
+    mem,
+    os::unix::io::RawFd,
+    ptr,
+io, ops::Neg};
+
+use num_traits::One;
+use libc::{msghdr, iovec, recvmsg, cmsghdr, CMSG_DATA, CMSG_FIRSTHDR,
+    CMSG_NXTHDR, CMSG_SPACE, SOL_SOCKET, SCM_RIGHTS, MSG_CTRUNC};
+
+#[derive(Debug)]
+pub struct MsgHdr<'a, State> {
+    // Invariant: mhdr is properly initalized with msg_name null, and with
+    // msg_iov and msg_control valid pointers for length msg_iovlen and
+    // msg_controllen respectively. The arrays that msg_iov and msg_control
+    // point to must outlive mhdr.
+    mhdr: msghdr,
+    state: State,
+    _phantom: PhantomData<&'a ()>,
+}
+
+// The type states fro MsgHdr.
+#[derive(Debug, Default)]
+pub struct RecvStart {}
+
+#[derive(Debug)]
+pub struct RecvEnd {
+    bytes_recvieved: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct SendStart {}
+
+struct FdsIter<'a> {
+    // Invariant: mhdr is initalized as described in MsgHdr.that has
+    // been filled in by a call to recvmsg.
+    mhdr: &'a msghdr,
+    // Invariant: cmsg is a valid cmsg based on mhdr (or None)
+    cmsg: Option<&'a cmsghdr>,
+    data: Option<FdsIterData>,
+}
+
+// Invariants:
+//      1. curr and end are non-null
+//      2. curr <= end
+//      3. the half-open range [curr, end) (if non-empty) must
+//          be all part of the same same array of initalized
+//          RawFd values.
+//      4. if curr != end then curr must be a valid pointer
+//  Note that neither curr nor end is assumed to be ali_gned.
+struct FdsIterData {
+    curr: *const RawFd,
+    end: *const RawFd,
+}
+
+impl<'a, State: Default> MsgHdr<'a, State>{
+    // Safety: iov must be valid for length iov_len and the array that iov points to
+    // must outlive the returned MsgHdr.
+    unsafe fn new(iov: *mut iovec, iov_len: usize, cmsg_buffer: &'a mut [u8]) -> Self {
+        let mhdr = {
+            // msghdr may have private members for padding. This ensures that they are zeroed.
+            let mut mhdr = mem::MaybeUninit::<libc::msghdr>::zeroed();
+            // Safety: we don't turn p into a reference or read from it
+            let p = mhdr.as_mut_ptr();
+            (*p).msg_name = ptr::null_mut();
+            (*p).msg_namelen = 0;
+            (*p).msg_iov = iov;
+            (*p).msg_iovlen = iov_len;
+            (*p).msg_control = cmsg_buffer.as_mut_ptr() as _;
+            (*p).msg_controllen = cmsg_buffer.len();
+            (*p).msg_flags = 0;
+            // Safety: we have initalized all 7 fields of mhdr and zeroed the padding
+            mhdr.assume_init()
+        };
+
+        // Invariant: msg_name is set to null; msg_control (and its len) are
+        // set based on a slice that outlives mhdr; the requirements on
+        // msg_iov (and its len) are precondition to this function.
+        Self {
+            mhdr,
+            state: Default::default(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a> MsgHdr<'a, RecvStart> {
+    /// Returns the size needed for a msghdr control buffer big
+    /// enough to hold `count` `RawFd`'s.
+    #[allow(dead_code)]
+    pub fn cmsg_buffer_fds_space(count: usize) -> usize {
+        // Safety: CMSG_SPACE is safe
+        unsafe { CMSG_SPACE((count * mem::size_of::<RawFd>()) as u32) as usize }
+    }
+
+    pub fn from_io_slice_mut(bufs: &'a mut [IoSliceMut], cmsg_buffer: &'a mut [u8]) -> Self {
+        // IoSliceMut guarentees ABI compatibility with iovec.
+        let iov: *mut iovec = bufs.as_mut_ptr() as *mut iovec;
+        let iov_len = bufs.len();
+
+        // Safety: iov is valid for iov_len because they both come from the same
+        // slice (bufs). The array that iov points to will outlive the returned
+        // MsgHdr because of the lifetime constraints on bufs and on MsgHdr.
+        unsafe { Self::new(iov, iov_len, cmsg_buffer) }
+    }
+
+    pub fn recv(mut self, sockfd: RawFd) -> io::Result<MsgHdr<'a, RecvEnd>> {
+        // Safety: the invariant on self.mhdr mean that it has been properly
+        // initalized for passing to recvmsg.
+        let count = call_res( || unsafe { recvmsg(sockfd, &mut self.mhdr, 0) })
+            .map(|c| c as usize)?;
+
+        // Invariant: self.mhdr satified the invariant at the start of this call.
+        // recvmsg can write into the buffers pointed to by the iovec's found
+        // in the array pointed to by mhdr.iov but won't change the array itself.
+        // recvmsg may change msg_controllen to the length of the actual control
+        // buffer read, but this will be no longer than the msg_controllen passed
+        // in so msg_control will still be a valid pointer for length
+        // msg_controllen.
+        Ok(MsgHdr {
+            mhdr: self.mhdr,
+            state: RecvEnd {
+                bytes_recvieved: count,
+            },
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<'a> MsgHdr<'a, RecvEnd> {
+    pub fn bytes_recvieved(&self) -> usize {
+        self.state.bytes_recvieved
+    }
+
+    pub fn was_control_truncated(&self) -> bool {
+        self.mhdr.msg_flags & MSG_CTRUNC != 0
+    }
+
+    pub fn fds_iter(&'a self) -> impl Iterator<Item=RawFd> + 'a {
+        // Safety: the invariant on self.mhdr means it is initalized
+        // appropriately. The trasition from RecvStart state to RecvEnd
+        // state means that recvmsg was called. The appropriate lifetimes
+        // for the buffers in mhdr are guarenteed by holding a shared
+        // reference to self and by the absence of other methods that
+        // can modify a MsgHdr<RecvEnd>.
+        unsafe { FdsIter::new(&self.mhdr) }
+    }
+}
+
+impl<'a> MsgHdr<'a, SendStart> {
+    // TODO: remove this when it is not longer necessary
+    #[allow(dead_code)]
+    pub fn from_io_slice(bufs: &'a [IoSlice], cmsg_buffer: &'a mut [u8]) -> Self {
+        // IoSlice guarentees ABI compatibility with iovec. sendmsg doesn't
+        // mutate the iovec array but the standard says it takes a mutable
+        // pointer so this transmutes he pointer into a mutable one. The Role
+        // constraint of Sender on MsgHdr will prevent calling recvmsg on the
+        // underlying msghdr.
+        let iov: *mut iovec = bufs.as_ptr() as *mut iovec;
+        let iov_len = bufs.len();
+
+        // Safety: iov is valid for iov_len because they both come from the same
+        // slice (bufs). The array that iov points to will outlive the returned
+        // MsgHdr because of the lifetime constraints on bufs and on MsgHdr.
+        unsafe { Self::new(iov, iov_len, cmsg_buffer) }
+    }
+}
+
+impl<'a> FdsIter<'a> {
+    // Safety: mhdr is initalized as described in invariant for MsgHdr and
+    // has been filled in by a call to recvmsg. The buffers pointed to
+    // by fields of mhdr must not be changed during the lifetime of the
+    // returned reference.
+    unsafe fn new(mhdr: &'a msghdr) -> Self {
+        // Safety: follows from pre-condition.
+        let cmsg = FdsIter::first_cmsg(mhdr);
+        // Safety: follows from pre-condition (especially the call to recvmsg).
+        let data = cmsg.and_then(|cmsg| FdsIterData::new(cmsg));
+
+        FdsIter {
+            // Invariant: follows from pre-condition.
+            mhdr,
+            // Invariant: cmsg is produced by first_cmsg based on mhdr
+            cmsg,
+            data,
+        }
+    }
+
+    // Safety: mhdr is initalized as described in invariant for MsgHdr and
+    // has been filled in by a call to recvmsg. The buffers pointed to
+    // by fields of mhdr must not be changed during the lifetime of the
+    // returned reference.
+    unsafe fn first_cmsg(mhdr: &'a msghdr) -> Option<&'a cmsghdr> {
+        // Safety: follows from pre-condition.
+        let cmsg = CMSG_FIRSTHDR(mhdr);
+        // Safety: if CMSG_FIRSTHDR returns a non-null pointer it will be a
+        // properly aligned pointer to a cmsghdr. It also guarentees that it
+        // points to a part of the msg_control that is big enough for a cmsghdr
+        // which means that the pointer is dereferenceable. Finally, the
+        // precondition on not changing the buffers of the fields pointed to by
+        // mhdr and the lifetime constraint on the functions return value
+        // enforce Rust's aliasing rules.
+        cmsg.as_ref()
+    }
+
+    fn advance_cmsg(&mut self) {
+        if let Some(cmsg) = self.cmsg {
+            // Safety: cmsg is a valid cmsg based on mhdr which has a
+            // msg_control array filled in by recvmsg (from the invariants).
+            // The call to CMSG_NXTHDR is thus safe by its defintion. If
+            // CMSG_NXTHDR returns a non-null pointer it will be a properly
+            // alligned pointer to a cmsghdr. It also points to a part of the
+            // msg_control that is big enough for a cmsghdr which means that
+            // the pointer is dereferenceable. Finally, the precondition on not
+            // changing the buffers of the fields pointed to by mhdr and the
+            // lifetime constraint on the functions return value enforce Rust's
+            // aliasing rules.
+            let new_cmsg = unsafe { CMSG_NXTHDR(self.mhdr, cmsg).as_ref() };
+
+            // Safety: follows from the invariant on msghdr and especially
+            // the requirement to have called recvmsg.
+            let new_data = new_cmsg.and_then(|cmsg| unsafe {FdsIterData::new(cmsg) });
+
+            // Invariant: new_cmsg is produced by a call to CMSG_NXTHDR.
+            self.cmsg = new_cmsg;
+            self.data = new_data;
+        }
+    }
+}
+
+impl<'a> Iterator for FdsIter<'a> {
+    type Item = RawFd;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.data.as_mut().and_then(|data| data.next()) {
+                Some(data) => return Some(data),
+                None => {
+                    self.advance_cmsg();
+                    if self.cmsg.is_none() {
+                        return None;
+                    }
+                }
+            };
+        }
+    }
+}
+
+impl FdsIterData {
+    // Safety: cmsg must be properly initalized for cmsg.cmsg_len bytes
+    // starting at cmsg. That is, the implict cmsg_data member of cmsg must
+    // be properly initalized.
+    unsafe fn new(cmsg: &cmsghdr) -> Option<Self> {
+        if cmsg.cmsg_level == SOL_SOCKET && cmsg.cmsg_type == SCM_RIGHTS {
+            // Safety: follows from pre-condition
+            let p_start = CMSG_DATA(cmsg) as *const u8;
+
+            assert!(cmsg.cmsg_len <= (isize::MAX as usize));
+            let pcmsg: *const cmsghdr = cmsg;
+            // Safety: follows from pre-condition,  from the defintion of a
+            // cmsg, and from the assertion above.
+            let p_end = (pcmsg.cast::<u8>()).offset(cmsg.cmsg_len as isize);
+
+            let data_size = (p_end as usize) - (p_start as usize);
+            // This may round down if the data portion is bigger than an
+            // integral number of RawFd's.
+            let fds_count: usize = data_size / mem::size_of::<RawFd>();
+
+            let curr = p_start.cast::<RawFd>();
+            // Safety: curr points to the first byte of the implict cmsg_data
+            // member of the cmsg which is properly initalized by the precondition;
+            // curr.offset(fds_count) is <= p_end by the way fds_count is calculated
+            // so it is also either in the implict cmsg_data member of cmsg or is
+            // one byte past the end; the assertion above guarentees that the offset
+            // in bytes implied by fds_count <= isize::MAX.
+            let end = curr.offset(fds_count as isize);
+
+
+            // Invariants:
+            //      1. curr is non-null by defintion of CMSG_DATA; end is
+            //          non-null by defintion of offset.
+            //      2. end is offset from curr by fds_count which is non-negative
+            //          so curr <= end.
+            //      3. cmsg is properly initalized (by the precondition) and is
+            //          of type SCM_RIGHTS which means that its data portion
+            //          is an array of RawFd's; the calculations of curr and
+            //          end above give the first and one-past-the-last elements
+            //          of this array so [curr, end) is the whole array of
+            //          RawFd's that make up the the data portion of cmsg.
+            //      4. Follows from 3.
+            Some(FdsIterData { curr, end })
+        } else {
+            None
+        }
+    }
+}
+
+impl Iterator for FdsIterData {
+    type Item = RawFd;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.curr < self.end {
+            // Safety: curr < end so follows from invariants 1, 3 and 4.
+            let next = unsafe { self.curr.read_unaligned() };
+
+            // Safety: curr < end so curr is valid by invariant 4;
+            // curr.offset(1) is either end or and element of
+            // [curr, end) by invariant 3 and is thus either one
+            // past the end of the RawFd array or in bounds for the
+            // RawFd array. The offset in bytes is sizeof::<RawFd>()
+            // which is (much) less than isize::MAX.
+            //
+            // Invariants: invariant 1 is maintained by defintion of offset();
+            // invariant 3 (from entry to method) and curr < end means that
+            // curr.offset(1) <= end so invariants 2 and 3 are maintained;
+            // invariant 3 being maintained imples that invariant 4 is maintained.
+            self.curr = unsafe { self.curr.offset(1) };
+
+            Some(next)
+        } else {
+            None
+        }
+    }
+}
+
+fn call_res<F, R>(mut f: F) -> Result<R, io::Error>
+where
+    F: FnMut() -> R,
+    R: One + Neg<Output = R> + PartialEq,
+{
+    let res = f();
+    if res == -R::one() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(res)
+    }
+}

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -35,7 +35,7 @@ pub struct MsgHdr<'a, State> {
     // state.
     mhdr: msghdr,
     state: State,
-    _phantom: PhantomData<&'a ()>,
+    _phantom: PhantomData<(&'a mut [iovec], &'a mut [u8])>,
 }
 
 trait NullableControl {}

--- a/src/net/iomsg.rs
+++ b/src/net/iomsg.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms
 
-//! Types to provide a safe interface around libc::recvmsg and libc::sendmsg.
+//! Types to provide a safe interface around `libc::recvmsg` and `libc::sendmsg`.
 
 use std::{
     convert::TryInto,
@@ -29,6 +29,7 @@ use libc::{
 use num_traits::One;
 
 #[derive(Debug)]
+/// The core type providing a safe interface to `libc::recvmsg` and `libc::sendmsg`.
 pub struct MsgHdr<'a, State> {
     // Invariant: mhdr is properly initalized with msg_name null, and with
     // msg_iov and msg_control valid pointers for length msg_iovlen and
@@ -117,7 +118,7 @@ pub struct SendEnd {
 impl NullableControl for SendEnd {}
 
 struct FdsIter<'a> {
-    // Invariant: mhdr is initalized as described in MsgHdr.that has
+    // Invariant: mhdr is initalized as described in MsgHdr that has
     // been filled in by a call to recvmsg.
     mhdr: &'a msghdr,
     // Invariant: cmsg is a valid cmsg based on mhdr (or None)
@@ -132,13 +133,13 @@ struct FdsIter<'a> {
 //          be all part of the same same array of initalized
 //          RawFd values.
 //      4. if curr != end then curr must be a valid pointer
-//  Note that neither curr nor end is assumed to be ali_gned.
+//  Note that neither curr nor end is assumed to be aligned.
 struct FdsIterData {
     curr: *const RawFd,
     end: *const RawFd,
 }
 
-// A safe owner of a contained RawFd.
+/// A safe owner of a contained RawFd.
 #[derive(Debug)]
 pub struct Fd {
     // Invariant: fd is None or Fd is the owner of the contained RawFd.
@@ -263,8 +264,8 @@ impl<'a> MsgHdr<'a, SendStart> {
     pub fn from_io_slice(bufs: &'a [IoSlice], cmsg_buffer: &'a mut [u8]) -> Self {
         // IoSlice guarentees ABI compatibility with iovec. sendmsg doesn't
         // mutate the iovec array but the standard says it takes a mutable
-        // pointer so this transmutes he pointer into a mutable one. The Role
-        // constraint of Sender on MsgHdr will prevent calling recvmsg on the
+        // pointer so this transmutes he pointer into a mutable one. The State
+        // constraint of SendStart on MsgHdr will prevent calling recvmsg on the
         // underlying msghdr.
         let iov: *mut iovec = bufs.as_ptr() as *mut iovec;
         let iov_len = bufs.len();
@@ -630,7 +631,6 @@ impl error::Error for CMsgBufferTooSmallError {}
 
 /// Returns the size needed for a msghdr control buffer big
 /// enough to hold `count` `RawFd`'s.
-#[allow(dead_code)]
 pub fn cmsg_buffer_fds_space(count: usize) -> usize {
     // Safety: CMSG_SPACE is safe
     unsafe { CMSG_SPACE((count * mem::size_of::<RawFd>()) as u32) as usize }


### PR DESCRIPTION
Remove the dependency on `nix` for the calls to `recvmsg()` and `sendmsg()`. We create our own safe abstractions in the new `net::iomsg` module to make calls directly using the types and functions in `libc`.

The main abstraction in `net::iomsg` is `MsgHdr` which uses a type state idiom to enforce a safe sequencing of calls for either sending or receiving. For sending the sequence is:

1. Create a `libc::msghdr` with a supplied `iovec` buffer and a `[u8]` buffer to use as the control buffer.
2. Encode a series of `RawFd`'s into the control buffer.
3. Call `libc::sendmsg` on a passed in `RawFd` using the prepared `libc::msghdr`.

For receiving the sequence is:

1. Create a `libc::msghdr` with a supplied `iovec` buffer and a `[u8]` buffer to use as the control buffer.
2. Call `libc::recvmsg` on a passed in `RawFd` using the prepared `libc::msghdr`.
3. Decode the received `RawFd`'s from the control buffer through an iterator.

We then refactor the `Read` and `Write` implementations on `net::UnixStream` to make use of the `MsgHdr` abstraction from `net::iomsg`. We use a `build.rs` script to generate constants from the `libc::CMSG_SPACE` function so that we can allocate the control buffer as an array on the stack rather than using dynamic allocation on each `sendmsg` and `recvmsg` call (this is necessary because `libc::CMSG_SPACE` is not `const` on a stable toolchain).

Note that some of the testing code still has a dev-dependency on `nix`.