### PR TITLE
fix(tokio): upgrade to tokio 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.39.0
+          - 1.45.0
 
     runs-on: ubuntu-latest
     if: github.actor != 'sbosnick-bot'
@@ -34,13 +34,6 @@ jobs:
           profile: default
           toolchain: ${{ matrix.rust }}
           override: true
-
-      - name: Patch Dependencies
-        if: matrix.rust == '1.39.0'
-        uses: actions-rs/cargo@v1
-        with:
-            command: update
-            args: --package remove_dir_all --precise 0.5.2
 
       - name: Check Format
         if: matrix.rust == 'stable'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ categories = ["asynchronous", "os::unix-apis"]
 [features]
 net-fd = ["tracing"]
 mio-fd = ["net-fd", "mio"]
-tokio-fd = ["mio-fd", "tokio", "socket2", "pin-project", "futures-core", "futures-util"]
+tokio-fd = ["tokio", "socket2", "pin-project", "futures-core", "futures-util"]
 
 [dependencies]
 tracing = {version = "0.1.15", optional = true}
 mio = {version = "0.6.22", optional = true}
-tokio = {version = "0.2.21", optional = true, features = ["io-driver", "io-util"]}
+tokio = {version = "1.0.0", optional = true, features = ["net"]}
 pin-project = {version = "0.4.22", optional = true}
 futures-core = {version = "0.3.5", optional = true}
 futures-util = {version = "0.3.5", optional = true}
@@ -30,7 +30,7 @@ num-traits = "0.2.14"
 nix = "0.17.0"
 tempfile = "3.1.0"
 assert_matches = "1.3.0"
-tokio = {version = "0.2.21", features = ["rt-threaded", "macros"]}
+tokio = {version = "1.0.0", features = ["rt-multi-thread", "macros", "io-util"]}
 
 [build-dependencies]
 libc = "0.2.80"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ traits. To include implementations of the traits enable the following features:
 ## Rust Version Requirements
 The library will always support the Rust version that is two earlier
 than the current stable version. The current Minimum Supported Rust
-Version (MSRV) is 1.39.0. Any change to the MSRV will be treated as a
+Version (MSRV) is 1.45.0. Any change to the MSRV will be treated as a
 breaking change for Semantic Version purposes.
 
 ## Semantic Version and Release

--- a/src/net.rs
+++ b/src/net.rs
@@ -709,6 +709,10 @@ impl UnixListener {
     pub fn incoming(&self) -> Incoming {
         Incoming { listener: self }
     }
+
+    pub(crate) fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.inner.set_nonblocking(nonblocking)
+    }
 }
 
 impl AsRawFd for UnixListener {


### PR DESCRIPTION
Upgrades the dependency on `tokio` to the stable 1.0.0 version. This necessitates changing the `tokio::UnixStream` and `tokio::UnixListener` implementations in this crate to use the `AsyncFd` type from the `tokio` crate. The `tokio` support in this crate no longer depends on `mio`.