### PR TITLE
chore(ci): upgrade the release plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             uses: actions-rs/cargo@v1
             with:
                 command: install
-                args: semantic-release-rust --version 1.0.0-alpha.6
+                args: semantic-release-rust --version 1.0.0-alpha.8
 
           - name: Stable Test
             uses: actions-rs/cargo@v1


### PR DESCRIPTION
Upgrade semantic-release-rust to the latest beta.
