### PR TITLE
ci: update version of the checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Version 3 is the latest version and there was some indication of
possible security vulerabilites in some earlier version.

fixes: #27
