### PR TITLE
ci: change release workflow to use GH PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
           - name: Run release-plz
             uses: MarcoIeni/release-plz-action@v0.2.2
             env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_TOKEN: ${{ secrets.FD_QUEUE_GITHUB_TOKEN }}
               CARGO_REGISTRY_TOKEN: ${{ secrets.FD_QUEUE_CRATES_IO }}


### PR DESCRIPTION
Change the release-plz step of the release workflow to use a personal
access token from the for GitHub access instead of the default
GITHUB_TOKEN. This allows release-plz to trigger checks when it creates
a release PR.
