### PR TITLE
fix(net): change libc dependencies to allow build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,10 @@ tokio = {version = "1.0.0", optional = true, features = ["net"]}
 pin-project = {version = "1.0.0", optional = true}
 futures-core = {version = "0.3.5", optional = true}
 futures-util = {version = "0.3.5", optional = true}
-libc = "0.2.80"
+libc = {version = "0.2.80", features = ["extra_traits"]}
 num-traits = "0.2.14"
 
 [dev-dependencies]
-nix = "0.23.0"
 tempfile = "3.1.0"
 assert_matches = "1.3.0"
 tokio = {version = "1.0.0", features = ["rt-multi-thread", "macros", "io-util"]}


### PR DESCRIPTION
Building the crate as a dependency from a foreign crate would fail with
an error about a missing Debug implementation on libc::msghdr. The same
build error was not reproducable locally.

The fix is to add the "extra_traits" feature to the libc dependency in
this crate. The nix dev-dependency had the "extra_traits" feature
already enabled. cargo's feature unificaton between the dev-dependencies
and the regular dependencies caused the "extra_traits" feature to be
enabled for libc on any local builds of this crate but not on builds
triggered by a dependency in a foreign crate.

Remove the nix dev-dependency to prevent masking this build error (and
because it is no longer necessary). Change the tests that had used nix
types to implement a shared memory type to instead use the std lib File
type (and the tempfile dependency to generate such a File).

Closes: #44
