### PR TITLE
ci: remove sbosnick-bot guard on ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           - 1.61.0
 
     runs-on: ubuntu-latest
-    if: github.actor != 'sbosnick-bot'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The ci workflow was conditional on the pull request not coming from
sbosnick-bot but the release workflow (though the release-plz step)
creates a new pull request acting as sbosnick-bot. This change (should)
allow the requied checks to run on that pull request so that it can be
merged.
